### PR TITLE
Add Nix package instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Primarily, this is a personal project since I recently switched to Neovim from E
 
 ## Installation
 
+[Nix](https://nixos.org/nix): `nix-env -iA nixpkgs.gex`
+
+### Building from source
+
 Gex is hosted on [crates.io](https://crates.io/crates/gex). You can either install from source, or you can use cargo:
 
 > **NOTE:** You will need [Rust](https://www.rust-lang.org/) on your system for this installation method.


### PR DESCRIPTION
I added a [Nix](https://nixos.org/nix) package for `gex` in https://github.com/NixOS/nixpkgs/pull/196931.