### PR TITLE
 disallow diff.external to fix diff preview

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -408,7 +408,7 @@ impl Status {
         }
 
         // Get the diff information for unstaged changes
-        let diff = git_process(&["diff"])?;
+        let diff = git_process(&["diff", "--no-ext-diff"])?;
         let diff = std::str::from_utf8(&diff.stdout).context("malformed stdout from `git diff`")?;
         let diffs = parse::parse_diff(diff)?;
         for mut file in &mut unstaged {
@@ -418,7 +418,7 @@ impl Status {
         }
 
         // Get the diff information for staged changes
-        let staged_diff = git_process(&["diff", "--cached"])?;
+        let staged_diff = git_process(&["diff", "--cached", "--no-ext-diff"])?;
         let staged_diff = std::str::from_utf8(&staged_diff.stdout)
             .context("malformed stdout from `git diff --cached`")?;
         let diffs = parse::parse_diff(staged_diff)?;


### PR DESCRIPTION
Hey really enjoy using gex, but I noticed that since I started using an external diff tool, gex would just show the whole file in the status view, instead of the lines that changed.

Since I am okay with using the standard diff in gex but want to use a different diff view on the cli I thought it would be a good idea to disable external diffing tools in gex with the `--no-ext-diff` flag from git.

This is obviously pretty hacky but judging from #13 it seems like you want to transition to [libgit2](https://github.com/rust-lang/git2-rs) eventually anyway, so I thought this would be appropriate for now.