### PR TITLE
Take minibuffer input asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased](https://github.com/Piturnah/gex/compare/v0.6.3...main)
+### Fixed
+- Minibuffer border messed up on terminal resize ([#65](https://github.com/Piturnah/gex/pull/65))
+
 ## [0.6.3](https://github.com/Piturnah/gex/compare/v0.6.2...v0.6.3) - 2023-08-30
 ### Fixed
 - Entering unreachable code on inserting trailing newline ([#62](https://github.com/Piturnah/gex/issues/62))

--- a/src/command.rs
+++ b/src/command.rs
@@ -161,7 +161,7 @@ impl GexCommand {
                 match subcmd {
                     SubCommand::Stash => MiniBuffer::push_command_output(&git_process(&["stash"])?),
                     SubCommand::Pop => {
-                        MiniBuffer::push_command_output(&git_process(&["stash", "pop"])?)
+                        MiniBuffer::push_command_output(&git_process(&["stash", "pop"])?);
                     }
                 }
                 status.fetch(repo, &config.options)?;

--- a/src/command.rs
+++ b/src/command.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::{Context, Result};
 use crossterm::{cursor, terminal};
 
-use crate::{branch::BranchList, config::Config, git_process, State, View};
+use crate::{branch::BranchList, config::Config, git_process, minibuffer::MiniBuffer, State, View};
 
 macro_rules! commands {
     ($($key:literal: $cmd:tt => [$($subkey:literal: $subcmd:tt),+$(,)?]),*$(,)?) => {
@@ -68,7 +68,6 @@ impl GexCommand {
     pub fn handle_input(self, key: char, state: &mut State, config: &Config) -> Result<()> {
         use SubCommand::*;
         let State {
-            ref mut minibuffer,
             ref mut status,
             ref mut view,
             repo,
@@ -84,7 +83,7 @@ impl GexCommand {
                 match subcmd {
                     SubCommand::New => {
                         let checkout = BranchList::checkout_new()?;
-                        minibuffer.push_command_output(&checkout);
+                        MiniBuffer::push_command_output(&checkout);
                         status.fetch(repo, &config.options)?;
                         *view = View::Status;
                     }
@@ -100,7 +99,7 @@ impl GexCommand {
                     SubCommand::Commit => {
                         crossterm::execute!(stdout(), terminal::LeaveAlternateScreen)
                             .context("failed to leave alternate screen")?;
-                        minibuffer.push_command_output(
+                        MiniBuffer::push_command_output(
                             &Command::new("git")
                                 .arg("commit")
                                 .stdout(Stdio::inherit())
@@ -113,7 +112,7 @@ impl GexCommand {
                             .context("failed to enter alternate screen")?;
                     }
                     SubCommand::Extend => {
-                        minibuffer.push_command_output(
+                        MiniBuffer::push_command_output(
                             &Command::new("git")
                                 .args(["commit", "--amend", "--no-edit"])
                                 .stdout(Stdio::inherit())
@@ -126,7 +125,7 @@ impl GexCommand {
                     SubCommand::Amend => {
                         crossterm::execute!(stdout(), terminal::LeaveAlternateScreen)
                             .context("failed to leave alternate screen")?;
-                        minibuffer.push_command_output(
+                        MiniBuffer::push_command_output(
                             &Command::new("git")
                                 .args(["commit", "--amend"])
                                 .stdout(Stdio::inherit())
@@ -148,9 +147,9 @@ impl GexCommand {
                 crossterm::execute!(stdout(), cursor::MoveToColumn(0), cursor::Show)?;
                 terminal::disable_raw_mode().context("failed to disable raw mode")?;
                 match subcmd {
-                    SubCommand::Remote => minibuffer.push_command_output(&git_process(&["push"])?),
+                    SubCommand::Remote => MiniBuffer::push_command_output(&git_process(&["push"])?),
                     SubCommand::Force => {
-                        minibuffer.push_command_output(&git_process(&["push", "--force"])?);
+                        MiniBuffer::push_command_output(&git_process(&["push", "--force"])?);
                     }
                 }
                 crossterm::execute!(stdout(), cursor::Hide)?;
@@ -160,9 +159,9 @@ impl GexCommand {
             Stash(subcmd) => {
                 use stash::SubCommand;
                 match subcmd {
-                    SubCommand::Stash => minibuffer.push_command_output(&git_process(&["stash"])?),
+                    SubCommand::Stash => MiniBuffer::push_command_output(&git_process(&["stash"])?),
                     SubCommand::Pop => {
-                        minibuffer.push_command_output(&git_process(&["stash", "pop"])?);
+                        MiniBuffer::push_command_output(&git_process(&["stash", "pop"])?)
                     }
                 }
                 status.fetch(repo, &config.options)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ fn run(clargs: &Clargs) -> Result<()> {
     std::env::set_current_dir(repo.path().parent().context("`.git` cannot be root dir")?)
         .context("failed to set working directory")?;
 
-    let mut minibuffer = MiniBuffer::new();
+    let minibuffer = MiniBuffer::new();
 
     let config = CONFIG.get_or_init(|| {
         Config::read_from_file(&clargs.config_file)
@@ -174,7 +174,7 @@ See https://github.com/Piturnah/gex/issues/13.", MessageType::Error);
         print!("{ResetAttributes}");
         match state.view {
             View::Status | View::Command(_) | View::Input(..) => {
-                state.status.render(&mut state.renderer)?
+                state.status.render(&mut state.renderer)?;
             }
             View::BranchList => state.branch_list.render(&mut state.renderer)?,
         }
@@ -247,7 +247,7 @@ See https://github.com/Piturnah/gex/issues/13.", MessageType::Error);
                         if state.status.cursor
                             < state.status.count_untracked + state.status.count_unstaged
                         {
-                            state.status.stage(&mut state.minibuffer)?;
+                            state.status.stage()?;
                             state.status.fetch(&state.repo, &config.options)?;
                         }
                     }
@@ -259,7 +259,7 @@ See https://github.com/Piturnah/gex/issues/13.", MessageType::Error);
                         if state.status.cursor
                             >= state.status.count_untracked + state.status.count_unstaged
                         {
-                            state.status.unstage(&mut state.minibuffer)?;
+                            state.status.unstage()?;
                             state.status.fetch(&state.repo, &config.options)?;
                         }
                     }

--- a/src/minibuffer.rs
+++ b/src/minibuffer.rs
@@ -71,7 +71,7 @@ impl MiniBuffer {
     }
 
     pub fn is_empty() -> bool {
-        MESSAGES.try_lock().expect("couldn't get rwlock").is_empty()
+        MESSAGES.try_lock().expect("couldn't get mutex").is_empty()
     }
 
     /// Push a new message onto the message stack.
@@ -79,7 +79,7 @@ impl MiniBuffer {
         if !msg.is_empty() {
             MESSAGES
                 .try_lock()
-                .expect("couldn't get rwlock")
+                .expect("couldn't get mutex")
                 .push((msg.trim().to_string(), msg_type));
         }
     }

--- a/src/status.rs
+++ b/src/status.rs
@@ -652,7 +652,7 @@ impl Status {
                     // waiting on the child process to finish.
                     .map(|mut stderr| stderr.read_to_string(&mut stderr_buf))
                     .context("failed to read stderr of child process")??;
-                mini_buffer.push(&stderr_buf, MessageType::Error);
+                MiniBuffer::push(&stderr_buf, MessageType::Error);
             }
         }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -596,7 +596,7 @@ impl Status {
         Ok(())
     }
 
-    fn stage_or_unstage(&mut self, command: Stage, mini_buffer: &mut MiniBuffer) -> Result<()> {
+    fn stage_or_unstage(&mut self, command: Stage) -> Result<()> {
         if self.file_diffs.is_empty() {
             return Ok(());
         }
@@ -663,12 +663,12 @@ impl Status {
         Ok(())
     }
 
-    pub fn stage(&mut self, mini_buffer: &mut MiniBuffer) -> Result<()> {
-        self.stage_or_unstage(Stage::Add, mini_buffer)
+    pub fn stage(&mut self) -> Result<()> {
+        self.stage_or_unstage(Stage::Add)
     }
 
-    pub fn unstage(&mut self, mini_buffer: &mut MiniBuffer) -> Result<()> {
-        self.stage_or_unstage(Stage::Reset, mini_buffer)
+    pub fn unstage(&mut self) -> Result<()> {
+        self.stage_or_unstage(Stage::Reset)
     }
 
     /// Toggles expand on the selected diff item.


### PR DESCRIPTION
Here we take the minibuffer input asynchronously, meaning that instead of calling `take_input` from within the event loop and then blocking until we have input, we instead switch to an alternative input view, providing a callback for when the input is received.

## Motivation

- Will fix the bug where resizing the terminal while in input mode messes up the borders.
- (Hopefully) easier to follow control flow. 