### PR TITLE
Adds a config option to sort branch list by most recent commit date

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ auto_expand_files = false
 auto_expand_hunks = true
 lookahead_lines = 5
 truncate_lines = true # `false` is not recommended - see #37
-sort_branches = "-committerdate" # filter to pass to `git branch --sort`
+sort_branches = "-committerdate" # filter to pass to `git branch --sort`. https://git-scm.com/docs/git-for-each-ref#_field_names
 ws_error_highlight = "new" # override git's diff.wsErrorHighlight
 
 # Named colours use the terminal colour scheme. You can also describe your colours

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ auto_expand_files = false
 auto_expand_hunks = true
 lookahead_lines = 5
 truncate_lines = true # `false` is not recommended - see #37
-sort_branch_list_by_commit_date = true
+sort_branches = "-committerdate" # filter to pass to `git branch --sort`
 ws_error_highlight = "new" # override git's diff.wsErrorHighlight
 
 # Named colours use the terminal colour scheme. You can also describe your colours

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ auto_expand_files = false
 auto_expand_hunks = true
 lookahead_lines = 5
 truncate_lines = true # `false` is not recommended - see #37
+sort_branch_list_by_commit_date = true
 ws_error_highlight = "new" # override git's diff.wsErrorHighlight
 
 # Named colours use the terminal colour scheme. You can also describe your colours

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -68,7 +68,13 @@ impl BranchList {
     }
 
     pub fn fetch(&mut self) -> Result<()> {
-        let output = git_process(&["branch"])?;
+        let config = CONFIG.get().expect("config wasn't initialised");
+
+        let output = if config.options.sort_branch_list_by_commit_date {
+            git_process(&["branch", "--sort=-committerdate"])?
+        } else {
+            git_process(&["branch"])?
+        };
 
         self.branches = std::str::from_utf8(&output.stdout)
             .context("broken stdout from `git branch`")?

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,7 @@ pub struct Options {
     pub auto_expand_hunks: bool,
     pub lookahead_lines: usize,
     pub truncate_lines: bool,
+    pub sort_branch_list_by_commit_date: bool,
     pub ws_error_highlight: WsErrorHighlight,
 }
 
@@ -63,6 +64,7 @@ impl Default for Options {
             auto_expand_hunks: true,
             lookahead_lines: 5,
             truncate_lines: true,
+            sort_branch_list_by_commit_date: false,
             ws_error_highlight: WsErrorHighlight::default(),
         }
     }
@@ -230,6 +232,7 @@ mod tests {
 auto_expand_hunks = true
 lookahead_lines = 5
 truncate_lines = true # `false` is not recommended - see #37
+sort_branch_list_by_commit_date = true
 ws_error_highlight = \"new\" # override git's diff.wsErrorHighlight
 
 # Named colours use the terminal colour scheme. You can also describe your colours
@@ -254,6 +257,7 @@ error = \"#cc241d\"
                     auto_expand_hunks: true,
                     lookahead_lines: 5,
                     truncate_lines: true,
+                    sort_branch_list_by_commit_date: true,
                     ws_error_highlight: WsErrorHighlight {
                         old: false,
                         new: true,

--- a/src/config.rs
+++ b/src/config.rs
@@ -228,11 +228,13 @@ mod tests {
     // Should be up to date with the example config in the README.
     #[test]
     fn parse_readme_example() {
-        const INPUT: &str = "auto_expand_files = false
+        const INPUT: &str = "
+[options]
+auto_expand_files = false
 auto_expand_hunks = true
 lookahead_lines = 5
 truncate_lines = true # `false` is not recommended - see #37
-sort_branches = \"-committerdate\"
+sort_branches = \"-committerdate\" # filter to pass to `git branch --sort`. https://git-scm.com/docs/git-for-each-ref#_field_names 
 ws_error_highlight = \"new\" # override git's diff.wsErrorHighlight
 
 # Named colours use the terminal colour scheme. You can also describe your colours
@@ -257,7 +259,7 @@ error = \"#cc241d\"
                     auto_expand_hunks: true,
                     lookahead_lines: 5,
                     truncate_lines: true,
-                    sort_branches: "-committerdate",
+                    sort_branches: Some("-committerdate".to_string()),
                     ws_error_highlight: WsErrorHighlight {
                         old: false,
                         new: true,

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,7 +45,7 @@ pub struct Options {
     pub auto_expand_hunks: bool,
     pub lookahead_lines: usize,
     pub truncate_lines: bool,
-    pub sort_branch_list_by_commit_date: bool,
+    pub sort_branches: Option<String>,
     pub ws_error_highlight: WsErrorHighlight,
 }
 
@@ -64,7 +64,7 @@ impl Default for Options {
             auto_expand_hunks: true,
             lookahead_lines: 5,
             truncate_lines: true,
-            sort_branch_list_by_commit_date: false,
+            sort_branches: None,
             ws_error_highlight: WsErrorHighlight::default(),
         }
     }
@@ -232,7 +232,7 @@ mod tests {
 auto_expand_hunks = true
 lookahead_lines = 5
 truncate_lines = true # `false` is not recommended - see #37
-sort_branch_list_by_commit_date = true
+sort_branches = \"-committerdate\"
 ws_error_highlight = \"new\" # override git's diff.wsErrorHighlight
 
 # Named colours use the terminal colour scheme. You can also describe your colours
@@ -257,7 +257,7 @@ error = \"#cc241d\"
                     auto_expand_hunks: true,
                     lookahead_lines: 5,
                     truncate_lines: true,
-                    sort_branch_list_by_commit_date: true,
+                    sort_branches: "-committerdate",
                     ws_error_highlight: WsErrorHighlight {
                         old: false,
                         new: true,


### PR DESCRIPTION
Solution for #79.

Adds a config option, `sort_branch_list_by_commit_date`, with a default value of false, that will allow users to sort the branch list on the checkout screen by most recent commit date. 